### PR TITLE
Do not create application icons on the desktop by default

### DIFF
--- a/src/settings/config/pages/page_session_options.cpp
+++ b/src/settings/config/pages/page_session_options.cpp
@@ -137,7 +137,7 @@ void page_session_options::LoadSettings(int screennum)
     loading = true;
 
     QSettings sessionsettings(DESKTOP_APP, DE_SESSION_SETTINGS);
-    ui->check_autoapplinks->setChecked( sessionsettings.value("AutomaticDesktopAppLinks",true).toBool() );
+    ui->check_autoapplinks->setChecked( sessionsettings.value("AutomaticDesktopAppLinks",false).toBool() );
     ui->line_session_time->setText( sessionsettings.value("TimeFormat","").toString() );
     ui->line_session_date->setText( sessionsettings.value("DateFormat","").toString() );
     int index = ui->combo_session_datetimeorder->findData( sessionsettings.value("DateTimeOrder","timeonly").toString() );


### PR DESCRIPTION
Continuation of https://github.com/rodlie/draco/pull/40. 

__Please review, something still may be missing.__ By default, the option is now unchecked but I still get those icons...