### PR TITLE
Add Wallpaper Settings to desktop context menu

### DIFF
--- a/src/desktop/LDesktop.cpp
+++ b/src/desktop/LDesktop.cpp
@@ -171,6 +171,11 @@ void LDesktop::SystemAbout()
     QProcess::startDetached(QString("%1 --about").arg(Draco::launcherApp()));
 }
 
+void LDesktop::WallpaperSettings()
+{
+    QProcess::startDetached("draco-settings --page wallpaper");
+}
+
 void LDesktop::SystemLock()
 {
     QProcess::startDetached("xscreensaver-command -lock");
@@ -465,6 +470,11 @@ void LDesktop::UpdateMenu(bool fast)
                         tr("About"),
                         this,
                         SLOT(SystemAbout()));
+    deskMenu->addSeparator();
+    deskMenu->addAction(LXDG::findIcon("preferences-desktop-wallpaper",""),
+                        tr("Wallpaper Settings"),
+                        this,
+                        SLOT(WallpaperSettings()));
     deskMenu->addSeparator();
     deskMenu->addAction(LXDG::findIcon("system-lock-screen",""),
                         tr("Lock Session"),

--- a/src/desktop/LDesktop.h
+++ b/src/desktop/LDesktop.h
@@ -95,6 +95,7 @@ public:
 
 public slots:
     void SystemAbout();
+    void WallpaperSettings();
     void SystemLock();
     void SystemLogout();
     void SystemTerminal();


### PR DESCRIPTION
Add Wallpaper Settings to desktop context menu:

![wallpaper](https://user-images.githubusercontent.com/2480569/81494832-4006e000-929b-11ea-9951-c35e078d1508.png)

This is where many users will be looking for it.

__Tested, working.__